### PR TITLE
fix(setup-panel): hydrate venue in edit mode

### DIFF
--- a/src/pages/Superadmin/components/merchant-accounts/merchant-setup-panel/useMerchantBundle.ts
+++ b/src/pages/Superadmin/components/merchant-accounts/merchant-setup-panel/useMerchantBundle.ts
@@ -14,7 +14,7 @@
  *
  * Per-card edit-save lives in Task 4.2, NOT here.
  */
-import { useQueries } from '@tanstack/react-query'
+import { useQueries, useQueryClient, type QueryClient } from '@tanstack/react-query'
 import {
   paymentProviderAPI,
   type MerchantAccount,
@@ -269,23 +269,55 @@ export interface UseMerchantBundleResult {
   errors: unknown[]
 }
 
+/**
+ * Fetch a merchant with its `venues[]` relation guaranteed populated.
+ *
+ * Why: the singular endpoint `GET /merchant-accounts/:id` does NOT include
+ * `venues[]` in its response — only the LIST endpoint does. In edit mode
+ * the panel needs `merchant.venues[0].id` to hydrate venue, slot, pricing,
+ * and the AngelPay account picker. Without it, those four cards stay
+ * "Pendiente" forever even though the merchant is fully configured.
+ *
+ * This helper falls back to `getAllMerchantAccounts()` (served from cache
+ * via `queryClient.fetchQuery` on `['merchant-accounts-all']` — the same
+ * key the parent page uses) when the singular response omits venues.
+ */
+async function getMerchantWithVenues(
+  queryClient: QueryClient,
+  id: string,
+): Promise<MerchantAccount> {
+  const m = await paymentProviderAPI.getMerchantAccount(id)
+  if (m.venues && m.venues.length > 0) return m
+  const all = await queryClient.fetchQuery({
+    queryKey: ['merchant-accounts-all'],
+    queryFn: () => paymentProviderAPI.getAllMerchantAccounts(),
+    staleTime: 30_000,
+  })
+  const enriched = all.find(a => a.id === id)
+  if (enriched?.venues && enriched.venues.length > 0) {
+    return { ...m, venues: enriched.venues }
+  }
+  return m
+}
+
 export function useMerchantBundle(merchantAccountId: string | undefined, enabled: boolean): UseMerchantBundleResult {
   const id = merchantAccountId ?? ''
   const isEnabled = enabled && !!id
+  const queryClient = useQueryClient()
 
   const queries = useQueries({
     queries: [
-      // 0. Merchant
+      // 0. Merchant (enriched with venues relation)
       {
         queryKey: ['merchant', id],
-        queryFn: () => paymentProviderAPI.getMerchantAccount(id),
+        queryFn: () => getMerchantWithVenues(queryClient, id),
         enabled: isEnabled,
       },
       // 1. AngelPay user account (depends on merchant — derive once it resolves)
       {
         queryKey: ['merchant-angelpay-account', id],
         queryFn: async (): Promise<AngelPayUserAccount | null> => {
-          const m = await paymentProviderAPI.getMerchantAccount(id)
+          const m = await getMerchantWithVenues(queryClient, id)
           if (!m.angelpayUserAccountId) return null
           const venueId = m.venues?.[0]?.id
           if (!venueId) return null
@@ -304,7 +336,7 @@ export function useMerchantBundle(merchantAccountId: string | undefined, enabled
       {
         queryKey: ['venue-pricing-by-merchant', id],
         queryFn: async (): Promise<VenuePricingStructure[]> => {
-          const m = await paymentProviderAPI.getMerchantAccount(id)
+          const m = await getMerchantWithVenues(queryClient, id)
           const venueId = m.venues?.[0]?.id
           if (!venueId) return []
           return paymentProviderAPI.getVenuePricingStructures({ venueId, active: true })
@@ -333,7 +365,7 @@ export function useMerchantBundle(merchantAccountId: string | undefined, enabled
       {
         queryKey: ['venue-payment-config-by-merchant', id],
         queryFn: async (): Promise<VenuePaymentConfig | null> => {
-          const m = await paymentProviderAPI.getMerchantAccount(id)
+          const m = await getMerchantWithVenues(queryClient, id)
           const venueId = m.venues?.[0]?.id
           if (!venueId) return null
           return paymentProviderAPI.getVenuePaymentConfig(venueId)


### PR DESCRIPTION
## Bug

User opened the Setup Panel in edit mode on the AMAENA AngelPay merchant (production) and saw the following four cards stuck as **Pendiente** even though the merchant is fully configured in the DB:

- 🏠 Venue → \"Pendiente\"
- 🎯 Slot → \"Pendiente\" (\"Slot de ruteo de pagos\")
- 💵 Precio al venue → \"Pendiente\" (\"lo que Avoqado le cobra al venue\")
- 🔑 Cuenta AngelPay → labeled \"Listo\" but with placeholder text \"Login del adquirente\" (couldn't resolve real email)

## Root cause

\`GET /api/v1/dashboard/superadmin/merchant-accounts/:id\` (the singular endpoint) does **not** include the \`venues[]\` relation in its response — only the LIST endpoint (\`GET /merchant-accounts\`) does. Backend log confirms:

\`\`\`
\"accountId\":\"cmpim2t11000fm92ats1yr8oz\",\"includeCredentials\":false,
\"message\":\"Retrieved merchant account\",\"providerId\":\"angelpay_provider_mx\"
\`\`\`

\`useMerchantBundle\` derives \`venueId\` from \`merchant.venues?.[0]?.id\` — when that's empty, four downstream queries short-circuit:

| Query | Depends on venueId | What broke |
| --- | --- | --- |
| AngelPay account lookup | yes — \`listAngelPayUserAccountsForVenue(venueId)\` | accounts list returns empty → no email match |
| Venue pricing structures | yes — \`getVenuePricingStructures({ venueId })\` | empty array → PricingCard stays Pendiente |
| Venue payment config | yes — \`getVenuePaymentConfig(venueId)\` | null → slot derivation falls back to mode='empty' |
| Venue slice in mapper | yes — \`venueId/Name/Slug\` | empty strings → VenueCard isValid is false |

## Fix

Frontend-only patch. Introduces \`getMerchantWithVenues(queryClient, id)\` inside \`useMerchantBundle\` that:

1. Calls \`paymentProviderAPI.getMerchantAccount(id)\` first
2. If the response includes \`venues[]\` non-empty → return as-is (current behavior)
3. Otherwise fall back to \`paymentProviderAPI.getAllMerchantAccounts()\` via \`queryClient.fetchQuery({ queryKey: ['merchant-accounts-all'], staleTime: 30s })\`, find the merchant by id, and stitch its venues into the response

The list endpoint is already cached under \`['merchant-accounts-all']\` by the parent \`MerchantAccounts.tsx\` page, so in practice the fallback is a cache hit, not a network call.

All four \`queryFn\`s inside \`useMerchantBundle\` that read \`merchant.venues[0].id\` now go through the wrapper, so the cascading failures resolve once the singular endpoint's missing relation is patched in.

## Verification

- \`npm run build\` ✅
- \`npx vitest run merchant-setup-panel/__tests__\` → 38/38 passing
- No backend changes needed — patch is contained to the dashboard.

## Test plan

- [ ] Open /superadmin/merchant-accounts on the deployed build (Cloudflare Pages preview link below)
- [ ] Click \`⚙️ Configurar\` on any existing AngelPay merchant (e.g. AMAENA, KEPLER, SALON AMAENA)
- [ ] Verify all 7 obligatory cards now show their real data:
  - Venue card shows the venue name + \"Listo\" badge
  - Slot card shows PRIMARY/SECONDARY/TERTIARY + \"Listo\" badge
  - Cost card shows the rates (already worked pre-patch)
  - Precio al venue shows the rates + \"Listo\" badge
  - Liquidación shows T+1/1/3/3 (already worked pre-patch)
- [ ] Click each card → edit dialog opens with hydrated values → save → mutation hits its endpoint → toast confirms

## Follow-up (out of scope here)

Backend should be updated to include \`venues[]\` in the singular endpoint response so this fallback isn't needed. Open a backend PR after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)